### PR TITLE
Use a benchmark harness

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,5 @@ author: David Kopec <david@oaksnow.com>
 description: A port of chess.js to Dart. chess.dart is a library for legal chess move generation, maintenance of chess game state, and conversion to and from the formats FEN and PGN.
 homepage: https://github.com/davecom/chess.dart
 dev_dependencies:
+  benchmark_harness: '>=1.0.0 <1.1.0'
   unittest: '>=0.9.3'

--- a/test/perft.dart
+++ b/test/perft.dart
@@ -1,24 +1,49 @@
 import "package:chess/chess.dart";
+import "package:benchmark_harness/benchmark_harness.dart";
+
+class PerftBenchmark extends BenchmarkBase {
+  final String fen;
+  final int depth;
+  final int nodes;
+  Chess chess;
+
+  PerftBenchmark(String fen, this.depth, this.nodes)
+      : this.fen = fen
+      , super("Perft(fen:'$fen')");
+
+  setup() {
+    chess = new Chess();
+    chess.load(fen);
+  }
+
+  teardown() {
+    chess = null;
+  }
+
+  run() {
+    int result = chess.perft(depth);
+    if (result != nodes) {
+      throw 'Wrong result: Expected <$nodes> but got <$result>.';
+    }
+  }
+}
 
 void main() {
-  Stopwatch stopwatch = new Stopwatch()
-  ..start();
-    List perfts = [
-    {'fen': 'r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1',
-      'depth': 3, 'nodes': 97862},
-    {'fen': '8/PPP4k/8/8/8/8/4Kppp/8 w - - 0 1',
-      'depth': 4, 'nodes': 89363},
-    {'fen': '8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1',
-      'depth': 4, 'nodes': 43238},
-    {'fen': 'rnbqkbnr/p3pppp/2p5/1pPp4/3P4/8/PP2PPPP/RNBQKBNR w KQkq b6 0 4',
-      'depth': 3, 'nodes': 23509},
-    ];
-
-    perfts.forEach((perft) {
-      Chess chess = new Chess();
-      chess.load(perft['fen']);
-  
-      var nodes = chess.perft(perft['depth']);
-    });
-  print(stopwatch.elapsedMilliseconds);
+  List perfts = [
+    new PerftBenchmark(
+        'r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1',
+        3, 97862),
+    new PerftBenchmark(
+        '8/PPP4k/8/8/8/8/4Kppp/8 w - - 0 1',
+        4, 89363),
+    new PerftBenchmark(
+        '8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1',
+        4, 43238),
+    new PerftBenchmark(
+        'rnbqkbnr/p3pppp/2p5/1pPp4/3P4/8/PP2PPPP/RNBQKBNR w KQkq b6 0 4',
+        3, 23509)
+  ];
+  for (BenchmarkBase perft in perfts) {
+    perft.report();
+  }
 }


### PR DESCRIPTION
Use a benchmark harness to (more accurately) measure performance of the perft  support.
