### PR TITLE
DDC and strong mode adjustments

### DIFF
--- a/lib/chess.dart
+++ b/lib/chess.dart
@@ -609,7 +609,7 @@ class Chess {
 
         /* pawn captures */
         for (int j = 2; j < 4; j++) {
-          var square = i + PAWN_OFFSETS[us][j];
+          int square = i + PAWN_OFFSETS[us][j];
           if ((square & 0x88) != 0) continue;
 
           if (board[square] != null && board[square].color == them) {
@@ -1643,9 +1643,9 @@ class Move {
 
 class State {
   final Move move;
-  final ColorMap kings;
+  final ColorMap<int> kings;
   final Color turn;
-  final ColorMap castling;
+  final ColorMap<int> castling;
   final int ep_square;
   final int half_moves;
   final int move_number;


### PR DESCRIPTION
The problem is that on line 613 it's trying to do a `bitwise &` on a inferred `num` object which doesn't support `bitwise &`. If you change the declaration type from `var` to `int`, it will enforce the `int` type which does provide bitwise operations. This should resolve the DDC warnings.

The `ColorMap` needed to specify the subtype of `T` generic. Note that I didn't get a strong mode warning on this until the code was executed, so there might be other strong mode changes needed that I haven't executed yet.  

#8 is the discussion behind this pull request