### PR TITLE
slightly improved pgn generation

### DIFF
--- a/lib/chess.dart
+++ b/lib/chess.dart
@@ -1302,17 +1302,23 @@ class Chess {
       reversed_history.add(undo_move());
     }
 
+    var start_move_number = 1;
+    if (header['FEN'] != null) {
+      final move_number_string = header['FEN'].split(' ')[5];
+      start_move_number = int.parse(move_number_string);
+    }
+
     final moves = <String?>[];
     var move_string = '';
-    var pgn_move_number = 1;
+    var pgn_move_number = start_move_number;
 
     /* build the list of moves.  a move_string looks like: "3. e3 e6" */
     while (reversed_history.isNotEmpty) {
       final move = reversed_history.removeLast()!;
 
-      /* if the position started with black to move, start PGN with 1. ... */
-      if (pgn_move_number == 1 && move.color == BLACK) {
-        move_string = '1. ...';
+      /* if the position started with black to move, start PGN with ${start_move_number}. ... */
+      if (pgn_move_number == start_move_number && move.color == BLACK) {
+        move_string = '$start_move_number. ...';
         pgn_move_number++;
       } else if (move.color == WHITE) {
         /* store the previous generated move_string if we have one */

--- a/test/tests.dart
+++ b/test/tests.dart
@@ -898,6 +898,33 @@ void main() {
       },
       {
         'moves': [
+          'e7+',
+          'Ke8',
+          'Ke6'
+        ],
+        'header': [],
+        'max_width': 80,
+        'starting_position': '3k4/8/3KP3/8/8/8/8/8 w - - 0 42',
+        'pgn':
+            '[SetUp "1"]\n[FEN "3k4/8/3KP3/8/8/8/8/8 w - - 0 42"]\n\n42. e7+ Ke8 43. Ke6',
+        'fen': '4k3/4P3/4K3/8/8/8/8/8 b - - 2 43'
+      },
+      {
+        'moves': [
+          'Ke8',
+          'e7',
+          'Kf7',
+          'Kd7'
+        ],
+        'header': [],
+        'max_width': 80,
+        'starting_position': '3k4/8/3KP3/8/8/8/8/8 b - - 0 39',
+        'pgn':
+            '[SetUp "1"]\n[FEN "3k4/8/3KP3/8/8/8/8/8 b - - 0 39"]\n\n39. ... Ke8 40. e7 Kf7 41. Kd7',
+        'fen': '8/3KPk2/8/8/8/8/8/8 b - - 2 41'
+      },
+      {
+        'moves': [
           'f3',
           'e5',
           'g4',


### PR DESCRIPTION
Pgn generation now takes into account the start move number of the game for the moves san part.

As a simple example, if the game starts with the following **FEN** code
```
3k4/8/3KP3/8/8/8/8/8 b - - 0 42
```

where it is black to move and the game starts with move number 42, then the moves part takes the start move number into account

```
42. ... Ke8 43. e7 Kf7 44. Kd7
```